### PR TITLE
Update flakeid.js fix a bug.

### DIFF
--- a/src/flakeid.js
+++ b/src/flakeid.js
@@ -39,7 +39,7 @@ export default class FlakeId {
     const bid = bTime + bMid + bSeq;
     let id = "";
 
-    for (let i = bid.length; i >= 0; i -= 4) {
+    for (let i = bid.length; i > 0; i -= 4) {
       id = parseInt(bid.substring(i - 4, i), 2).toString(16) + id;
     }
 


### PR DESCRIPTION

const flake = new FlakeId({ timeOffset: (2013 - 1970) * 31536000 * 1000 });
when use this timeOffset to init
current time 2018.8.8 16:10 GMT+0800
Date.now()  == 1533715827740

    for (let i = bid.length; i >= 0; i -= 4) {
      id = parseInt(bid.substring(i - 4, i), 2).toString(16) + id;
    }
bid is `101001010111011100111010011000001100110000000001000000000000`
id will be `NaNa5773a60cc01000`

what happened here is 
bid.substring(i - 4, i) get a empty string where i == 0

for (let i = bid.length; i >= 0; i -= 4) {
      let ss = bid.substring(i - 4, i);
      console.log(`${i} [${ss}]`);
      console.log(`${i} [${parseInt(ss, 2)}]`);
      id = parseInt(bid.substring(i - 4, i), 2).toString(16) + id;
    }

60 [0000]
60 [0]
56 [0000]
56 [0]
52 [0000]
52 [0]
48 [0001]
48 [1]
44 [0000]
44 [0]
40 [0000]
40 [0]
36 [0111]
36 [7]
32 [0000]
32 [0]
28 [1010]
28 [10]
24 [1111]
24 [15]
20 [0100]
20 [4]
16 [0111]
16 [7]
12 [0111]
12 [7]
8 [0101]
8 [5]
4 [1010]
4 [10]
0 []
0 [NaN]