### PR TITLE
Bugfix: Possible Duplicate Ids When Sequence Reset

### DIFF
--- a/lib/flakeid.js
+++ b/lib/flakeid.js
@@ -28,8 +28,7 @@ function () {
   (0, _createClass2.default)(FlakeId, [{
     key: "gen",
     value: function gen() {
-      var time = Date.now(),
-          bTime = (time - this.timeOffset).toString(2); //get the sequence number
+      var time = Date.now();
 
       if (this.lastTime == time) {
         this.seq++;
@@ -37,13 +36,18 @@ function () {
         if (this.seq > 4095) {
           this.seq = 0; //make system wait till time is been shifted by one millisecond
 
-          while (Date.now() <= time) {}
+          while (Date.now() <= time) {
+            time = Date.now()
+          }
         }
       } else {
         this.seq = 0;
       }
 
       this.lastTime = time;
+      
+      var bTime = (time - this.timeOffset).toString(2); //get the sequence number
+      
       var bSeq = this.seq.toString(2),
           bMid = this.mid.toString(2); //create sequence binary bit
 


### PR DESCRIPTION
When waiting for next milisecond for resetting sequence number, time is not set to current time, which probably results in duplicate ids.